### PR TITLE
Let the user to create a simple gist

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -60,11 +60,11 @@ class  DashboardController < ApplicationController
 
   private
 
-  def create_gist_params
-    params.require(:gist).permit(
-      :description,
-      :public,
-      files_attributes: %i[filename content]
-    )
-  end
+    def create_gist_params
+      params.require(:gist).permit(
+        :description,
+        :public,
+        files_attributes: %i[filename content]
+      )
+    end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -32,4 +32,39 @@ class  DashboardController < ApplicationController
   def unstar_gist
     gist_action("unstar")
   end
+
+  def new_gist
+    @gist = Gist.new
+    @gist.build_file
+  end
+
+  def create_gist
+    @gist = Gist.new create_gist_params
+
+    if @gist.valid?
+      resource_response = current_client.create_gist @gist.create_payload
+
+      if current_client.last_response.status == 201
+        flash[:success] = <<~TXT.squish
+          The gist was successfully created at #{resource_response[:html_url]}
+        TXT
+        redirect_to root_path
+      else
+        flash[:danger] = "We couldn't create the gist."
+        render :new_gist
+      end
+    else
+      render :new_gist
+    end
+  end
+
+  private
+
+  def create_gist_params
+    params.require(:gist).permit(
+      :description,
+      :public,
+      files_attributes: %i[filename content]
+    )
+  end
 end

--- a/app/models/gist.rb
+++ b/app/models/gist.rb
@@ -1,0 +1,52 @@
+class Gist
+  include ActiveModel::Model
+
+  class File
+    include ActiveModel::Model
+
+    attr_accessor :filename, :content
+
+    validates :content, presence: true
+  end
+
+  attr_accessor :description, :public, :files
+
+  validates :description, presence: true
+
+  def initialize(attributes = {})
+    @files = []
+
+    super
+  end
+
+  def files_attributes=(attributes)
+    attributes.each do |index, file_params|
+      @files.push Gist::File.new(file_params)
+    end
+  end
+
+  def build_file(file_attributes = {})
+    @files.push Gist::File.new(file_attributes)
+  end
+
+  def valid?
+    super & files.map(&:valid?).reduce(&:&)
+  end
+
+  def create_payload
+    {
+      description: description,
+      public: ActiveRecord::Type::Boolean.new.cast(public),
+      files: format_files
+    }
+  end
+
+  private
+
+    def format_files
+      files.reduce({}) do |memo, file|
+        memo[file.filename] = file.content
+        memo
+      end
+    end
+end

--- a/app/models/gist.rb
+++ b/app/models/gist.rb
@@ -45,7 +45,7 @@ class Gist
 
     def format_files
       files.reduce({}) do |memo, file|
-        memo[file.filename] = file.content
+        memo[file.filename] = { content: file.content }
         memo
       end
     end

--- a/app/views/application/_alert.html.erb
+++ b/app/views/application/_alert.html.erb
@@ -1,0 +1,19 @@
+<% type_to_alert_modifier_class = Hash.new do |hash, key| %>
+  <% if key == "alert" %>
+    <% hash[key] = "alert-danger" %>
+  <% elsif key == "notice" %>
+    <% hash[key] = "alert-primary" %>
+  <% else %>
+    <% hash[key] = "alert-#{key}" %>
+  <% end %>
+<% end %>
+
+<% flash.each do |type, message| %>
+  <div class="alert <%= type_to_alert_modifier_class[type] %> alert-dismissible fade show" role="alert">
+    <%= message %>
+
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+<% end %>

--- a/app/views/application/_model_errors.html.erb
+++ b/app/views/application/_model_errors.html.erb
@@ -1,0 +1,15 @@
+<% return if model.errors.empty? %>
+
+<div class="alert alert-danger alert-dismissible fade show" role="alert">
+  <%= pluralize(model.errors.count, "error") %> prohibited this <%= model_name %> from being saved:
+
+  <ul class="mb-0">
+    <% model.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+  </ul>
+
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>

--- a/app/views/dashboard/new_gist.html.erb
+++ b/app/views/dashboard/new_gist.html.erb
@@ -1,0 +1,46 @@
+<div class="row">
+  <div class="col-auto mr-auto">
+    <h3>New Gist</h3>
+  </div>
+  <div class="col-auto right-gap">
+    <%= link_to "Back", dashboard_index_path, {class: 'btn btn-sm btn-outline-secondary'} %>
+  </div>
+</div>
+<div class="row">
+  <div class="col-12">
+    <%= form_with model: @gist, url: create_gist_path, method: :post, local: true do |form| %>
+      <%= render "model_errors", model: @gist, model_name: "gist" %>
+
+      <div class="form-group">
+        <%= form.label :description %>
+        <%= form.text_field :description, class: "form-control", placeholder: "Gist description…" %>
+      </div>
+
+      <%= form.fields_for :files do |file_form| %>
+        <%= render "model_errors", model: file_form.object, model_name: "file" %>
+
+        <div class="form-group">
+          <%= file_form.label :filename %>
+          <%= file_form.text_field :filename, class: "form-control", placeholder: "Filename including extension…" %>
+        </div>
+
+        <div class="form-group">
+          <%= file_form.label :content %>
+          <%= file_form.text_area :content, class: "form-control", rows: 15 %>
+        </div>
+      <% end %>
+
+      <div class="form-check">
+        <%= form.check_box :public, class: "form-check-input" %>
+        <%= form.label :public, "Create public gist", class: "form-check-label" %>
+      </div>
+
+      <div class="row">
+        <div class="col-auto mr-auto"></div>
+        <div class="col-auto right-gap">
+          <%= form.submit "Create", class: "btn btn-outline-primary" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,7 @@
         <% end %>
       </header>
       <main role="main" class="top-gap">
+        <%= render "alert" %>
         <%= yield %>
       </main>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
           <%= image_tag "logo_transparent_new.png", width: 50, style: "margin-right: 10px;" %>
           <%= link_to "Gist Catch", root_path, {class: "navbar-brand nav-header"}%>
           <div class="align-right">
+            <%= link_to 'New Gist', new_gist_path, class: 'btn btn-outline-secondary btn-sm' %>
             <%= link_to 'Sign out', destroy_user_session_path, {method: 'delete', class: 'btn btn-outline-secondary btn-sm'}%>
           </div>
         </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   root to: "welcome#index"
 
   resources :dashboard
+  get "new_gist", to: "dashboard#new_gist", as: "new_gist"
+  post "create_gist", to: "dashboard#create_gist", as: "create_gist"
   get "get_gists/:login", to: "dashboard#get_gists", as: "get_gists"
   get "gist_content(/:gistid)", to: "dashboard#gist_content", as: "gist_content"
   put "star_gist(/:gistid)", to: "dashboard#star_gist", as: "star_gist"


### PR DESCRIPTION
Simple implementation for letting users to create gists. For simplification, only a single file is created. More can be added later.

Closes #15.

![nyc2bd12wv](https://user-images.githubusercontent.com/381395/47761635-f1d15380-dc97-11e8-8a20-c5585bd0f61d.gif)

---

##### Extract component to render a model's errors

e.g. `<%= render "model_errors", model: @gist %>`

---

##### Render Rails flash messages with Bootstrap's alerts

Alerts are now rendered in the layout. All color variations from [Bootstrap][1] can be used.

e.g. `flash[:success]` will render `.alert-success`, `flash[:dark]` will render `.alert-dark`, and so on.

Rails' default `alert` type is rendered as "danger" and `notice` type as "primary".

[1]: getbootstrap.com/docs/4.0/components/alerts