### PR TITLE
Display gist files of image type

### DIFF
--- a/app/helpers/kramdown_helper.rb
+++ b/app/helpers/kramdown_helper.rb
@@ -4,11 +4,18 @@ module KramdownHelper
 
   def format_collection(content_collection)
     filecontent_html = ""
-    content_collection.each do |content|
-      f_key, f_details = content
-      filecontent_html << "<h5>#{f_key}</h5><hr><div>#{kramdown_rouge_prepare(f_details[:content], f_details[:language])}</div>"
+    content_collection.each do |filename, details|
+      filecontent_html << "<h5>#{filename}</h5><hr><div>#{file_preview(details)}</div>"
     end
     filecontent_html
+  end
+
+  def file_preview(details)
+    if details[:type] =~ /image/
+      image_tag(details[:raw_url], alt: details[:filename])
+    else
+      kramdown_rouge_prepare(details[:content], details[:language])
+    end
   end
 
   def kramdown_rouge_prepare(text, lang)


### PR DESCRIPTION
Closes #28.

@shivanibhanwal, I know you were assigned to this, but I just tried something. Please take a look when you can.

|Before|After|
|-|-|
|![before](https://user-images.githubusercontent.com/381395/47811806-74542480-dd25-11e8-92e7-5cfcd7c1fc9f.png)|![after](https://user-images.githubusercontent.com/381395/47811823-7ddd8c80-dd25-11e8-957a-8e2eb67d8c70.png)|