### PR TITLE
Add multiple files to a gist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "kramdown"
 # gem 'capistrano-rails', group: :development
 
 # Dynamic nested forms using jQuery made easy.
-gem "cocoon", "~> 1.2"
+gem "cocoon", github: "dnagir/cocoon", ref: "0a1f9804f841"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.1.0", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem "kramdown"
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# Dynamic nested forms using jQuery made easy.
+gem "cocoon", "~> 1.2"
+
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.1.0", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/dnagir/cocoon.git
+  revision: 0a1f9804f841e8b207524da97aa0c4b23acbecb5
+  ref: 0a1f9804f841
+  specs:
+    cocoon (1.2.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -298,6 +305,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   chromedriver-helper
+  cocoon!
   coffee-rails (~> 4.2)
   devise
   faraday-http-cache

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,4 +16,5 @@
 //= require jquery3
 //= require popper
 //= require bootstrap
+//= require cocoon
 //= require_tree .

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -52,8 +52,7 @@ class  DashboardController < ApplicationController
   end
 
   def new_gist
-    @gist = Gist.new
-    @gist.build_file
+    @gist = Gist.new(files: [Gist::File.new])
   end
 
   def create_gist

--- a/app/models/gist.rb
+++ b/app/models/gist.rb
@@ -56,8 +56,11 @@ class Gist
   private
 
     def format_files
-      files.reduce({}) do |memo, file|
+      files.each.with_index.reduce({}) do |memo, (file, index)|
+        file.filename = "gistfile#{index + 1}.txt" if file.filename.blank?
+
         memo[file.filename] = { content: file.content }
+
         memo
       end
     end

--- a/app/models/gist.rb
+++ b/app/models/gist.rb
@@ -7,26 +7,38 @@ class Gist
     attr_accessor :filename, :content
 
     validates :content, presence: true
+
+    def new_record?
+      true
+    end
+
+    def marked_for_destruction?
+      false
+    end
+
+    def _destroy
+      false
+    end
   end
 
   attr_accessor :description, :public, :files
 
-  validates :description, presence: true
+  validates :files, presence: true
 
-  def initialize(attributes = {})
-    @files = []
-
-    super
+  def files
+    @files ||= []
   end
 
   def files_attributes=(attributes)
-    attributes.each do |index, file_params|
-      @files.push Gist::File.new(file_params)
-    end
+    @files = attributes.map do |_key, file_params|
+      next nil if file_params[:content].blank?
+
+      Gist::File.new(file_params)
+    end.compact
   end
 
   def build_file(file_attributes = {})
-    @files.push Gist::File.new(file_attributes)
+    Gist::File.new(file_attributes)
   end
 
   def valid?

--- a/app/views/dashboard/_file_fields.html.erb
+++ b/app/views/dashboard/_file_fields.html.erb
@@ -1,0 +1,20 @@
+<div class="nested-fields">
+  <div class="form-group">
+    <%= f.label :filename %>
+
+    <div class="input-group">
+      <%= f.text_field :filename, class: "form-control", placeholder: "Filename including extension…" %>
+      <div class="input-group-append">
+        <% icon = capture do %>
+          <i class="fa fa-trash"></i>
+        <% end %>
+        <%= link_to_remove_association icon, f, class: "btn btn-outline-secondary" %>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :content %>
+    <%= f.text_area :content, class: "form-control", rows: 15 %>
+  </div>
+</div>

--- a/app/views/dashboard/new_gist.html.erb
+++ b/app/views/dashboard/new_gist.html.erb
@@ -16,27 +16,25 @@
         <%= form.text_field :description, class: "form-control", placeholder: "Gist description…" %>
       </div>
 
-      <%= form.fields_for :files do |file_form| %>
-        <%= render "model_errors", model: file_form.object, model_name: "file" %>
-
-        <div class="form-group">
-          <%= file_form.label :filename %>
-          <%= file_form.text_field :filename, class: "form-control", placeholder: "Filename including extension…" %>
-        </div>
-
-        <div class="form-group">
-          <%= file_form.label :content %>
-          <%= file_form.text_area :content, class: "form-control", rows: 15 %>
-        </div>
-      <% end %>
+      <div id="files">
+        <%= form.fields_for :files do |file_form| %>
+          <%= render "file_fields", f: file_form %>
+        <% end %>
+      </div>
 
       <div class="form-check">
         <%= form.check_box :public, class: "form-check-input" %>
         <%= form.label :public, "Create public gist", class: "form-check-label" %>
       </div>
 
-      <div class="row">
-        <div class="col-auto mr-auto"></div>
+      <div class="row mt-3">
+        <div class="col-auto mr-auto">
+          <%= link_to_add_association "Add File", form, :files,
+            class: "btn btn-outline-secondary",
+            "data-association-insertion-node" => "#files",
+            "data-association-insertion-method" => "append"
+          %>
+        </div>
         <div class="col-auto right-gap">
           <%= form.submit "Create", class: "btn btn-outline-primary" %>
         </div>

--- a/spec/models/gist_spec.rb
+++ b/spec/models/gist_spec.rb
@@ -53,6 +53,20 @@ describe Gist do
       expect(payload[:files]["test.rb"]).to have_key(:content)
       expect(payload[:files]["test.rb"][:content]).to eq "puts 'Hello'"
     end
+
+    it "uses 'gistfile{index}.txt when the file has no filename'" do
+      subject = described_class.new files: [
+        Gist::File.new(filename:  "", content: "1"),
+        Gist::File.new(filename:  "", content: "2")
+      ]
+
+      payload = subject.create_payload
+
+      expect(payload[:files]).to have_key("gistfile1.txt")
+      expect(payload[:files]["gistfile1.txt"][:content]).to eq "1"
+      expect(payload[:files]).to have_key("gistfile2.txt")
+      expect(payload[:files]["gistfile2.txt"][:content]).to eq "2"
+    end
   end
 end
 

--- a/spec/models/gist_spec.rb
+++ b/spec/models/gist_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+describe Gist do
+  it "validates presence for files" do
+    subject = described_class.new files: nil
+
+    expect(subject).not_to be_valid
+    expect(subject.errors.added?(:files, :blank)).to eq true
+  end
+
+  describe "#valid?" do
+    it "returns true if the gitst and its files are all valid" do
+      subject = described_class.new description: "description", files: [
+        Gist::File.new(filename: "test2.rb", content: "puts 'Hello'")
+      ]
+
+      expect(subject).to be_valid
+    end
+
+    it "also calls save for each file" do
+      subject = described_class.new files: [
+        Gist::File.new(filename: "test.rb", content: nil),
+        Gist::File.new(filename: "test2.rb", content: "puts 'Hello'")
+      ]
+
+      subject.valid?
+
+      expect(subject).not_to be_valid
+      expect(subject.files[0]).not_to be_valid
+      expect(subject.files[1]).to be_valid
+    end
+  end
+
+  describe "#create_payload" do
+    it "returns a hash" do
+      subject = described_class.new description: "test", public: "1", files: []
+
+      payload = subject.create_payload
+
+      expect(payload[:description]).to eq "test"
+      expect(payload[:public]).to eq true
+      expect(payload[:files]).to be_empty
+    end
+
+    it "formats the :files key so in the expected format for the API" do
+      subject = described_class.new files: [
+        Gist::File.new(filename:  "test.rb", content: "puts 'Hello'")
+      ]
+
+      payload = subject.create_payload
+
+      expect(payload[:files]).to have_key("test.rb")
+      expect(payload[:files]["test.rb"]).to have_key(:content)
+      expect(payload[:files]["test.rb"][:content]).to eq "puts 'Hello'"
+    end
+  end
+end
+
+describe Gist::File do
+  it "validates presence for content" do
+    subject = described_class.new content: nil
+
+    expect(subject).not_to be_valid
+    expect(subject.errors.added?(:content, :blank)).to eq true
+  end
+end


### PR DESCRIPTION
- [x] Setup the Cocoon gem for dealing with dynamic nested forms.
  - [x] Use [this particular commit](https://github.com/nathanvda/cocoon/pull/223) to allow it to work with non-ActiveRecord models.
- [x] Let more than one file to be submitted when creating a gist.
- [x] Remove presence validation for the gist's description.
- [x] Add presence validation for the gist's files.
- [x] Add some tests.

![ng4jrzjp0y](https://user-images.githubusercontent.com/381395/47954049-53c5dd80-df64-11e8-8fae-52009533e36c.gif)
